### PR TITLE
sm-api.inc: fix a typo

### DIFF
--- a/recipes-core/stx-ha/sm-api.inc
+++ b/recipes-core/stx-ha/sm-api.inc
@@ -22,7 +22,7 @@ do_install_prepend () {
 	install -d -m 0755 ${D}/${systemd_system_unitdir}
 	install -m 644 scripts/sm_api.ini ${D}/${sysconfdir}/sm
 	install -m 755 scripts/sm-api ${D}/${sysconfdir}/init.d
-	install -m 644 scripts/sm-api.service ${D}/${systemd_system_unitdir/}
+	install -m 644 scripts/sm-api.service ${D}/${systemd_system_unitdir}
 	install -m 644 scripts/sm-api.conf ${D}/${sysconfdir}/pmon.d
 	install -m 644 etc/sm-api/policy.json ${D}/${sysconfdir}/sm-api
 }


### PR DESCRIPTION
This causes stx-ha do_install failed with:
tmp/work/corei7-64-poky-linux/stx-ha/19.05-r0/temp/run.do_install.16712:
Bad substitution

fixed: #5

Signed-off-by: Jackie Huang <jackie.huang@windriver.com>